### PR TITLE
Restructured VS proj namespace/folders

### DIFF
--- a/src/Umbraco.Courier.Contrib.Resolvers/GridCellDataResolvers/DocTypeGridEditorGridCellResolver.cs
+++ b/src/Umbraco.Courier.Contrib.Resolvers/GridCellDataResolvers/DocTypeGridEditorGridCellResolver.cs
@@ -10,7 +10,7 @@ using Umbraco.Courier.Core.ProviderModel;
 using Umbraco.Courier.DataResolvers.PropertyDataResolvers;
 using Umbraco.Courier.ItemProviders;
 
-namespace Umbraco.Courier.Contrib.Resolvers.DocTypeGridEditor
+namespace Umbraco.Courier.Contrib.Resolvers.GridCellDataResolvers
 {
     /// <summary>
     /// DocTypeGridEditor Grid Cell Resolver for DTGE by Matt Brailsford & Lee Kelleher.

--- a/src/Umbraco.Courier.Contrib.Resolvers/GridCellDataResolvers/LeBlenderGridCellResolver.cs
+++ b/src/Umbraco.Courier.Contrib.Resolvers/GridCellDataResolvers/LeBlenderGridCellResolver.cs
@@ -9,7 +9,7 @@ using Umbraco.Courier.Core.ProviderModel;
 using Umbraco.Courier.DataResolvers.PropertyDataResolvers;
 using Umbraco.Courier.ItemProviders;
 
-namespace Umbraco.Courier.Contrib.Resolvers.LeBlender
+namespace Umbraco.Courier.Contrib.Resolvers.GridCellDataResolvers
 {
     public class LeBlenderGridCellResolver : GridCellResolverProvider
     {

--- a/src/Umbraco.Courier.Contrib.Resolvers/PropertyDataResolvers/NestedContentPropertyDataResolver.cs
+++ b/src/Umbraco.Courier.Contrib.Resolvers/PropertyDataResolvers/NestedContentPropertyDataResolver.cs
@@ -10,7 +10,7 @@ using Umbraco.Courier.Core.ProviderModel;
 using Umbraco.Courier.DataResolvers;
 using Umbraco.Courier.ItemProviders;
 
-namespace Umbraco.Courier.Contrib.Resolvers.NestedContent
+namespace Umbraco.Courier.Contrib.Resolvers.PropertyDataResolvers
 {
     /// <summary>
     /// Nested Content Property Data Resolver for Nested Content by Matt Brailsford & Lee Kelleher.

--- a/src/Umbraco.Courier.Contrib.Resolvers/PropertyDataResolvers/VortoPropertyDataResolver.cs
+++ b/src/Umbraco.Courier.Contrib.Resolvers/PropertyDataResolvers/VortoPropertyDataResolver.cs
@@ -9,7 +9,7 @@ using Umbraco.Courier.Core.ProviderModel;
 using Umbraco.Courier.DataResolvers;
 using Umbraco.Courier.ItemProviders;
 
-namespace Umbraco.Courier.Contrib.Resolvers.Vorto
+namespace Umbraco.Courier.Contrib.Resolvers.PropertyDataResolvers
 {
     /// <summary>
     /// Vorto Property Data Resolver for Vorto by Matt Brailsford.

--- a/src/Umbraco.Courier.Contrib.Resolvers/Umbraco.Courier.Contrib.Resolvers.csproj
+++ b/src/Umbraco.Courier.Contrib.Resolvers/Umbraco.Courier.Contrib.Resolvers.csproj
@@ -286,11 +286,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Action.cs" />
-    <Compile Include="DocTypeGridEditor\DocTypeGridEditorGridCellResolver.cs" />
-    <Compile Include="LeBlender\LeBlenderGridCellResolver.cs" />
-    <Compile Include="NestedContent\NestedContentPropertyDataResolver.cs" />
+    <Compile Include="GridCellDataResolvers\DocTypeGridEditorGridCellResolver.cs" />
+    <Compile Include="GridCellDataResolvers\LeBlenderGridCellResolver.cs" />
+    <Compile Include="PropertyDataResolvers\NestedContentPropertyDataResolver.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Vorto\VortoPropertyDataResolver.cs" />
+    <Compile Include="PropertyDataResolvers\VortoPropertyDataResolver.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
As per the discussion on #4, I've grouped the data-resolvers into folders by their type (Property or GridCell resolvers).

This will reduce the number of namespaces used in the project/assembly.