### PR TITLE
JSON values with double quotes around them need to be properly escape…

### DIFF
--- a/src/Umbraco.Courier.Contrib.Resolvers/StringExtensions.cs
+++ b/src/Umbraco.Courier.Contrib.Resolvers/StringExtensions.cs
@@ -1,0 +1,12 @@
+﻿namespace Umbraco.Courier.Contrib.Resolvers
+{
+    //From: http://stackoverflow.com/a/21455488/5018
+    public static class StringExtensions
+    {
+        public static string EscapeForJson(this string text)
+        {
+            var quoted = System.Web.Helpers.Json.Encode(text);
+            return quoted.Substring(1, quoted.Length - 2);
+        }
+    }
+}

--- a/src/Umbraco.Courier.Contrib.Resolvers/Umbraco.Courier.Contrib.Resolvers.csproj
+++ b/src/Umbraco.Courier.Contrib.Resolvers/Umbraco.Courier.Contrib.Resolvers.csproj
@@ -292,6 +292,7 @@
     <Compile Include="PropertyDataResolvers\NestedContentPropertyDataResolver.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PropertyDataResolvers\VortoPropertyDataResolver.cs" />
+    <Compile Include="StringExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
…d in the JSON string builder

Some editors can have values stored in them that refer to document types that no longer exist, handled with a null check

With regards to the invalid JSON; instead of building this JSON:

Edit: Github doesn't let me insert invalid JSON either 😛 screenshot then:

![image](https://cloud.githubusercontent.com/assets/304656/20840875/01e724e0-b8b2-11e6-920e-c30b4870213d.png)

it will now build valid JSON: 

```
	{
		"name": "CTAs - SideBar",
		"image": "9f312170-f411-450d-bc2c-b9f84e931392",
		"memberName": "Jane Smith",
		"quote": "\"This is a great quote\"",
		"location": "New York"
	}
```

