### PR TITLE
Updated package links (Icon & MIT)

### DIFF
--- a/build/Package.build.xml
+++ b/build/Package.build.xml
@@ -30,7 +30,7 @@
 		<Copyright>Umbraco</Copyright>
 		<Owners>Umbraco</Owners>
 		<Summary>This project contains community contributions for the Umbraco deployment tool, Courier. Primarily this project offers data-resolvers for the most popular Umbraco community packages - these are used by Courier (and Umbraco Cloud) to aid with the deployment and transferring of content/property-data to a target environment.</Summary>
-		<IconUrl>http://umbraco.com/media/357769/100px_transparent.png</IconUrl>
+		<IconUrl>https://umbraco.com/media/357769/100px_transparent.png</IconUrl>
 		<Tags>umbraco</Tags>
 		<Language>en-GB</Language>
 		<RequireLicenseAcceptance>false</RequireLicenseAcceptance>

--- a/build/Package.build.xml
+++ b/build/Package.build.xml
@@ -18,8 +18,8 @@
 		<Readme>This project contains community contributions for the Umbraco deployment tool, Courier. Primarily this project offers data-resolvers for the most popular Umbraco community packages - these are used by Courier (and Umbraco Cloud) to aid with the deployment and transferring of content/property-data to a target environment.</Readme>
 		<AuthorName>Umbraco</AuthorName>
 		<AuthorUrl>https://umbraco.com/</AuthorUrl>
-		<PackageLicenseName>MIT license</PackageLicenseName>
-		<PackageLicenseUrl>http://www.opensource.org/licenses/mit-license.php</PackageLicenseUrl>
+		<PackageLicenseName>MIT License</PackageLicenseName>
+		<PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
 		<ProjectUrl>https://umbraco.com/</ProjectUrl>
 	</PropertyGroup>
 


### PR DESCRIPTION
- Updated the scheme of the `IconUrl` to use HTTPS, it saves the redirect roundtrip when people visit the NuGet package page
- Updated the package's MIT license URL to use the canonical version