### PR TITLE
Fix for issue #20

### DIFF
--- a/src/Umbraco.Courier.Contrib.Resolvers/GridCellDataResolvers/LeBlenderGridCellResolver.cs
+++ b/src/Umbraco.Courier.Contrib.Resolvers/GridCellDataResolvers/LeBlenderGridCellResolver.cs
@@ -149,7 +149,7 @@ namespace Umbraco.Courier.Contrib.Resolvers.GridCellDataResolvers
                 set
                 {
                     string str = value as string;
-                    if (str != null && _isQuoted)
+                    if (str != null && (_isQuoted || str == "¤"))
                     {
                         // We stripped quotes off so put them back now
                         JRawValue = new JRaw("\"" + str + "\"");


### PR DESCRIPTION
Without this fix, we can turn `"value": null` into invalid json `"value": ¤` when we really need `"value": "¤"`. I suspect `¤` was introduced in Courier v3 as a prevalue lookup marker. I didn't see this problem on 2.52.14.