### PR TITLE
AppVeyor - NuGet deploy from master

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ version: 1.0.{build}
 # Do not build on tags
 skip_tags: true
 
-
 build_script:
   - cd Build
   - Package.build.cmd %APPVEYOR_BUILD_VERSION%
@@ -13,8 +12,10 @@ artifacts:
   - path: Releases\*.nupkg
   
 deploy:
-  provider: NuGet
-  api_key:
-    secure: SPZoI6dtnTnukMvoB6U7XA6QGBR6fpseGdPE3QG0I2p2Iauz/b5Oj2hzQQp7Y2q1
-  skip_symbols: false    
-  artifact: /.*\.nupkg/
+  - provider: NuGet
+    api_key:
+      secure: SPZoI6dtnTnukMvoB6U7XA6QGBR6fpseGdPE3QG0I2p2Iauz/b5Oj2hzQQp7Y2q1
+    skip_symbols: false
+    artifact: /.*\.nupkg/
+    on:
+      branch: master


### PR DESCRIPTION
Updates AppVeyor build script to only deploy to NuGet when building from the "master" branch.

Closes #6