### PR TITLE
DTGE/NC fixes for nested JSON serialized values

### DIFF
--- a/src/Umbraco.Courier.Contrib.Resolvers/StringExtensions.cs
+++ b/src/Umbraco.Courier.Contrib.Resolvers/StringExtensions.cs
@@ -1,12 +1,20 @@
 ﻿namespace Umbraco.Courier.Contrib.Resolvers
 {
-    //From: http://stackoverflow.com/a/21455488/5018
-    public static class StringExtensions
+    internal static class StringExtensions
     {
+        //From: http://stackoverflow.com/a/21455488/5018
         public static string EscapeForJson(this string text)
         {
             var quoted = System.Web.Helpers.Json.Encode(text);
             return quoted.Substring(1, quoted.Length - 2);
+        }
+
+        //From: https://github.com/umbraco/Umbraco-CMS/blob/dev-v7/src/Umbraco.Core/StringExtensions.cs#L123
+        public static bool DetectIsJson(this string input)
+        {
+            input = input.Trim();
+            return (input.StartsWith("{") && input.EndsWith("}"))
+                   || (input.StartsWith("[") && input.EndsWith("]"));
         }
     }
 }


### PR DESCRIPTION
When an NC is used within a DTGE cell, the serialization of the nested value causes a problem during extraction. Only during extraction, we should not serialize the JSON values, but return them as raw values.

The NC resolver needed to refactored to use `object`s rather than `JToken`s, it was causing type casting issues.

_Also added `DetectIsJson` string extension method, this is taken from Umbraco.Core, as it's marked as `internal`, but could be removed if you wanted to include this project in the `InternalsVisibleTo`?_