### PR TITLE
fix issue #27

### DIFF
--- a/src/Umbraco.Courier.Contrib.Resolvers/GridCellDataResolvers/DocTypeGridEditorGridCellResolver.cs
+++ b/src/Umbraco.Courier.Contrib.Resolvers/GridCellDataResolvers/DocTypeGridEditorGridCellResolver.cs
@@ -27,6 +27,9 @@ namespace Umbraco.Courier.Contrib.Resolvers.GridCellDataResolvers
                 if (cell.Value is JValue)
                     return false;
 
+                if (cell.Value.Type == JTokenType.Array)
+                    return false;
+
                 return cell.Value["dtgeContentTypeAlias"] != null && cell.Value["value"] != null;
             }
             catch (Exception ex)


### PR DESCRIPTION
This fixes this exception:

```
2017-03-20 11:07:00,905 [193] ERROR Umbraco.Courier.Contrib.Resolvers.GridCellDataResolvers.DocTypeGridEditorGridCellResolver - [Thread 59] Error reading grid cell value:
System.ArgumentException: Accessed JArray values with invalid key value: "dtgeContentTypeAlias". Int32 array index expected.
```
The exception was thrown when cell.Value is an array because you can't call cell.Value["dtgeContentTypeAlias"] when cell.Value is an array.  If it's an array, then it isn't a DocTypeGridEditor.
