### PR TITLE
#47: Wrap MultiUrlPickerPropertyDataResolver's DeserializeObject<JArray> in try catch

### DIFF
--- a/src/Umbraco.Courier.Contrib.Resolvers/PropertyDataResolvers/MultiUrlPickerPropertyDataResolver.cs
+++ b/src/Umbraco.Courier.Contrib.Resolvers/PropertyDataResolvers/MultiUrlPickerPropertyDataResolver.cs
@@ -24,7 +24,16 @@ namespace Umbraco.Courier.Contrib.Resolvers.PropertyDataResolvers
             if (propertyData == null || propertyData.Value == null)
                 return;
 
-            var links = JsonConvert.DeserializeObject<JArray>(propertyData.Value.ToString());
+            JArray links = null;
+            try
+            {
+                links = JsonConvert.DeserializeObject<JArray>(propertyData.Value.ToString());
+            }
+            catch (Exception ex)
+            {
+                CourierLogHelper.Error<MultiUrlPickerPropertyDataResolver>($"There was a problem deserializing RJP.MultiUrlPicker data: {propertyData.Value.ToString()}", ex);
+            }
+
             if (links == null)
                 return;
 

--- a/src/Umbraco.Courier.Contrib.Resolvers/PropertyDataResolvers/MultiUrlPickerPropertyDataResolver.cs
+++ b/src/Umbraco.Courier.Contrib.Resolvers/PropertyDataResolvers/MultiUrlPickerPropertyDataResolver.cs
@@ -31,7 +31,7 @@ namespace Umbraco.Courier.Contrib.Resolvers.PropertyDataResolvers
             }
             catch (Exception ex)
             {
-                CourierLogHelper.Error<MultiUrlPickerPropertyDataResolver>($"There was a problem deserializing RJP.MultiUrlPicker data: {propertyData.Value.ToString()}", ex);
+                CourierLogHelper.Error<MultiUrlPickerPropertyDataResolver>(String.Format("There was a problem deserializing RJP.MultiUrlPicker data: {0}", propertyData.Value.ToString()), ex);
             }
 
             if (links == null)


### PR DESCRIPTION
This is related to this issue that I opened:
https://github.com/umbraco/Umbraco.Courier.Contrib/issues/47

I am just wrapping the `Umbraco.Courier.Contrib.Resolvers.PropertyDataResolvers.MultiUrlPickerPropertyDataResolver`'s `PackagingProperty` json deserialization in a try/catch and logging any errors. This seems like something useful. The real reason I did this is because for one of our projects, wrapping this deserialization in a try/catch prevents exceptions from being thrown there in the first place. I'm not sure anyone will be able to reproduce that part. It seems very strange to me.

Let me know if you want more explanation or justification for this change.