### PR TITLE
#50: Set up InnerContentPropertyDataResolver to detect inner content doctype

### DIFF
--- a/src/Umbraco.Courier.Contrib.Resolvers/PropertyDataResolvers/InnerContentPropertyDataResolver.cs
+++ b/src/Umbraco.Courier.Contrib.Resolvers/PropertyDataResolvers/InnerContentPropertyDataResolver.cs
@@ -227,7 +227,8 @@ namespace Umbraco.Courier.Contrib.Resolvers.PropertyDataResolvers
         private DocumentType GetDocumentType(string docTypeAlias, IDictionary<string, DocumentType> cache)
         {
             //don't look it up if we already have done that
-            if (!cache.TryGetValue(docTypeAlias, out var documentType))
+            DocumentType documentType;
+            if (!cache.TryGetValue(docTypeAlias, out documentType))
             {
                 documentType = ExecutionContext.DatabasePersistence.RetrieveItem<DocumentType>(new ItemIdentifier(docTypeAlias, ItemProviderIds.documentTypeItemProviderGuid));
                 cache[docTypeAlias] = documentType;
@@ -238,7 +239,8 @@ namespace Umbraco.Courier.Contrib.Resolvers.PropertyDataResolvers
         private DocumentType GetDocumentType(Guid docTypeGuid, IDictionary<string, DocumentType> cache)
         {
             //don't look it up if we already have done that
-            if (!cache.TryGetValue(docTypeGuid.ToString(), out var documentType))
+            DocumentType documentType;
+            if (!cache.TryGetValue(docTypeGuid.ToString(), out documentType))
             {
                 var matchingContentType = ApplicationContext.Current.Services.ContentTypeService.GetAllContentTypes().FirstOrDefault(c => c.Key == docTypeGuid);
                 if (matchingContentType != null)

--- a/src/Umbraco.Courier.Contrib.Resolvers/PropertyDataResolvers/InnerContentPropertyDataResolver.cs
+++ b/src/Umbraco.Courier.Contrib.Resolvers/PropertyDataResolvers/InnerContentPropertyDataResolver.cs
@@ -48,7 +48,7 @@ namespace Umbraco.Courier.Contrib.Resolvers.PropertyDataResolvers
 
         private void AddDataTypeDependencies(DataType item)
         {
-            if (item?.Prevalues == null || item.Prevalues.Count == 0)
+            if (item == null || item.Prevalues == null || item.Prevalues.Count == 0)
                 return;
 
             var json = item.Prevalues.FirstOrDefault(x => x.Alias.InvariantEquals("contentTypes"));
@@ -64,6 +64,7 @@ namespace Umbraco.Courier.Contrib.Resolvers.PropertyDataResolvers
             foreach (var contentType in contentTypes)
             {
                 DocumentType documentType = null;
+                Guid documentTypeGuid;
                 var documentTypeAlias = contentType["icContentTypeAlias"];
                 var documentTypeGuidString = contentType["icContentTypeGuid"];
                 if (documentTypeAlias != null)
@@ -71,7 +72,7 @@ namespace Umbraco.Courier.Contrib.Resolvers.PropertyDataResolvers
                     var documentTypeAliasString = documentTypeAlias.ToString();
                     documentType = GetDocumentType(documentTypeAliasString, resolvedDocTypes);
                 }
-                else if (documentTypeGuidString != null && Guid.TryParse(documentTypeGuidString.ToString(), out var documentTypeGuid))
+                else if (documentTypeGuidString != null && Guid.TryParse(documentTypeGuidString.ToString(), out documentTypeGuid))
                 {
                     documentType = GetDocumentType(documentTypeGuid, resolvedDocTypes);
                 }
@@ -113,6 +114,7 @@ namespace Umbraco.Courier.Contrib.Resolvers.PropertyDataResolvers
                 foreach (var innerContentItem in innerContentItems)
                 {
                     DocumentType documentType = null;
+                    Guid documentTypeGuid;
                     var documentTypeAlias = innerContentItem["icContentTypeAlias"];
                     var documentTypeGuidString = innerContentItem["icContentTypeGuid"];
                     if (documentTypeAlias != null)
@@ -120,7 +122,7 @@ namespace Umbraco.Courier.Contrib.Resolvers.PropertyDataResolvers
                         var documentTypeAliasString = documentTypeAlias.ToString();
                         documentType = GetDocumentType(documentTypeAliasString, resolvedDocTypes);
                     }
-                    else if (documentTypeGuidString != null && Guid.TryParse(documentTypeGuidString.ToString(), out var documentTypeGuid))
+                    else if (documentTypeGuidString != null && Guid.TryParse(documentTypeGuidString.ToString(), out documentTypeGuid))
                     {
                         documentType = GetDocumentType(documentTypeGuid, resolvedDocTypes);
                     }


### PR DESCRIPTION
by icContentTypeGuid as well as icContentTypeAlias

This is related to issue #50 here https://github.com/umbraco/Umbraco.Courier.Contrib/issues/50. InnerContent version 2.0.4 identifies the doctype of each inner content row using the `icContentTypeGuid` property. However, `Umbraco.Courier.Contrib`'s data resolve is only set up to look for a doctype identified by `icContentTypeAlias`. I am adding support for both identifiers. 